### PR TITLE
🔥 Less logging by removing access log from log ouput

### DIFF
--- a/ledfx/rootfs/etc/nginx/nginx.conf
+++ b/ledfx/rootfs/etc/nginx/nginx.conf
@@ -27,11 +27,7 @@ events {
 http {
     include /etc/nginx/includes/mime.types;
 
-    log_format homeassistant '[$time_local] $status '
-                             '$http_x_forwarded_for($remote_addr) '
-                             '$request ($http_user_agent)';
-
-    access_log              /proc/1/fd/1 homeassistant;
+    access_log              off;
     client_max_body_size    4G;
     default_type            application/octet-stream;
     gzip                    on;


### PR DESCRIPTION
# Proposed Changes

Reduces log output from the NGINX proxy by turning off the access logs
