### PR TITLE
🤖 Let dependabot handle upgrades

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,8 @@ updates:
     schedule:
       interval: daily
       time: "06:00"
+  - package-ecosystem: "pip"
+    directory: "/ledfx"
+    schedule:
+      interval: daily
+      time: "06:00"


### PR DESCRIPTION
# Proposed Changes

Let dependabot handle the upgrade of Python package if possible.

As the LedFX project has been picked up again, this would help us to keep up with upstream.
